### PR TITLE
Re-fixes #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "g33k-logger": "^0.1.0",
     "lame": "^1.2.2",
     "lodash": "^2.4.2",
-    "node-mpg123-util": "0.0.2",
+    "node-mpg123-util": "0.0.3",
     "request": "^2.51.0",
     "speaker": "^0.2.5",
     "underscore.string": "^3.0.2"


### PR DESCRIPTION
I cant't build mpg123-util@0.0.2 on node 6.4 neither 7.* but version 0.0.3 goes well as of #3 fixed using version 0.0.2